### PR TITLE
Make j and k behave as they do Vim when soft-wrap is enabled

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,6 +60,10 @@ esc = ["collapse_selection", "keep_primary_selection"]
 "*" = ["move_char_right", "move_prev_word_start", "move_next_word_end", "search_selection", "search_next"]
 "#" = ["move_char_right", "move_prev_word_start", "move_next_word_end", "search_selection", "search_prev"]
 
+# Make j and k behave as they do Vim when soft-wrap is enabled
+j = "move_line_down"
+k = "move_line_up"
+
 # Extend and select commands that expect a manual input can't be chained
 # I've kept d[X] commands here because it's better to at least have the stuff you want to delete
 # selected so that it's just a keystroke away to delete


### PR DESCRIPTION
According to the [FAQ](https://github.com/helix-editor/helix/wiki/FAQ#can-the-jk-bindings-be-changed-to-ignore-soft-wrapping-when-using-a-count-like-3j), it is known that Helix will not change the intuitiveness of j/k. Therefore, manually modify the configuration file to make it behave like Vim